### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/GoogleSpreadsheetParser/src/main/java/client/Utils/XmlParseUtils.java
+++ b/GoogleSpreadsheetParser/src/main/java/client/Utils/XmlParseUtils.java
@@ -41,7 +41,7 @@ public class XmlParseUtils {
     private static Set<String> brokenLinks = new HashSet<String>();
     private static String trailingspace = " ";
 
-    private static String doiPrefix = "http://dx.doi.org/";
+    private static String doiPrefix = "https://doi.org/";
     private static String pmcIdPrefix = "http://www.ncbi.nlm.nih.gov/pmc/articles/";
     private static String pmIdPrefix = "http://www.ncbi.nlm.nih.gov/pubmed/";
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!